### PR TITLE
Removes dependency pydub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - 2026-09-09
+
+### Changed
+- Removes pydub from read_audio and replaces it with soundfile.
+- Removes pydub from dependencies because it's now rendered obsolete
+
 ## [1.4.1] - 2026-09-09
 
 Second `iterate-fat-llama` run (5 cycles), continuing directly from 1.4.0, focused on closing that release's known gaps: the persistent lack of measurable added detail, and further performance work.

--- a/analysis.py
+++ b/analysis.py
@@ -1,16 +1,15 @@
 import matplotlib.pyplot as plt
+import soundfile as sf
 import numpy as np
 import scipy.signal as signal
-from pydub import AudioSegment
 import soundfile as sf
 
 def read_mp3(file_path):
-    audio = AudioSegment.from_mp3(file_path)
-    data = np.array(audio.get_array_of_samples())
-    if audio.channels == 2:
+    data, frame_rate = sf.read(file_path)
+    if data.ndim == 2:
         data = data.reshape((-1, 2))
         data = data.mean(axis=1)  # Convert to mono
-    return data, audio.frame_rate
+    return data, frame_rate
 
 def read_flac(file_path):
     data, sample_rate = sf.read(file_path)

--- a/fat_llama_fftw/audio_fattener/feed.py
+++ b/fat_llama_fftw/audio_fattener/feed.py
@@ -4,7 +4,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import pyfftw
-from pydub import AudioSegment
 import soundfile as sf
 from mutagen.mp3 import MP3
 from mutagen.flac import FLAC
@@ -69,9 +68,7 @@ def read_audio(file_path, format):
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"File {file_path} not found.")
 
-    audio = AudioSegment.from_file(file_path, format=format)
-    samples = np.array(audio.get_array_of_samples())
-    sample_rate = audio.frame_rate
+    samples, sample_rate = sf.read(file_path)
     bitrate = None
 
     if format == 'mp3':
@@ -90,10 +87,10 @@ def read_audio(file_path, format):
         duration_seconds = len(audio) / 1000.0
         bitrate = (len(samples) * 8) / duration_seconds
 
-    if audio.channels == 2:
+    if samples.ndim == 2:
         samples = samples.reshape((-1, 2))
 
-    return sample_rate, samples, bitrate, audio
+    return sample_rate, samples, bitrate
 
 
 def write_audio(file_path, sample_rate, data, format):
@@ -594,17 +591,13 @@ def upscale(
         )
 
     logger.info(f"Loading {source_format.upper()} file...")
-    sample_rate, samples, bitrate, audio = read_audio(input_file_path,
+    sample_rate, samples, bitrate = read_audio(input_file_path,
                                                        format=source_format)
     if bitrate:
         logger.info(
             f"Original {source_format.upper()} bitrate: "
             f"{bitrate / 1000:.2f} kbps"
         )
-
-    samples = np.array(audio.get_array_of_samples())
-    if audio.channels == 2:
-        samples = samples.reshape((-1, 2))
 
     target_bitrate = target_bitrate_kbps * 1000
     upscale_factor = round(target_bitrate / bitrate) if bitrate else 4

--- a/fat_llama_fftw/audio_fattener/feed.py
+++ b/fat_llama_fftw/audio_fattener/feed.py
@@ -65,7 +65,7 @@ def _fft_thread_count(n):
 
 
 def read_audio(file_path, format):
-    if not os.path.exists(file_path):
+    if isinstance(file_path, str) and not os.path.exists(file_path):
         raise FileNotFoundError(f"File {file_path} not found.")
 
     samples, sample_rate = sf.read(file_path)

--- a/fat_llama_fftw/tests/test_feed.py
+++ b/fat_llama_fftw/tests/test_feed.py
@@ -33,25 +33,23 @@ _INPUT_TEST_MP3 = os.path.join(_REPO_ROOT, 'input_test.mp3')
 
 class TestFeed(unittest.TestCase):
 
-    @patch('fat_llama_fftw.audio_fattener.feed.AudioSegment.from_file')
+    @patch('fat_llama_fftw.audio_fattener.feed.sf.read')
     @patch('fat_llama_fftw.audio_fattener.feed.MP3')
     @patch('os.path.exists', return_value=True)
-    def test_read_audio(self, mock_exists, mock_mp3, mock_from_file):
-        mock_audio = MagicMock()
-        mock_audio.frame_rate = 44100
-        mock_audio.channels = 2
-        mock_audio.get_array_of_samples.return_value = np.arange(
-            44100 * 4, dtype=np.int16)
-        mock_from_file.return_value = mock_audio
+    def test_read_audio(self, mock_exists, mock_mp3, mock_read):
+        frame_rate = 44100
+        samples = np.arange(
+            44100 * 4, dtype=np.int16).reshape(-1, 2)
+        mock_read.return_value = (samples, frame_rate)
         mock_mp3.return_value.info.bitrate = 1411000
 
-        sample_rate, samples, bitrate, audio = read_audio('test.mp3', 'mp3')
+        sample_rate, samples, bitrate = read_audio(_INPUT_TEST_MP3, 'mp3')
         self.assertEqual(sample_rate, 44100)
         self.assertEqual(samples.shape, (44100 * 4 // 2, 2))
         # The bitrate must be the one reported by the MP3 tag reader, not None.
         self.assertEqual(bitrate, 1411000)
         # The returned AudioSegment must be the decoded object itself.
-        self.assertIs(audio, mock_audio)
+        #self.assertIs(audio, mock_audio)
         # Stereo de-interleaving must preserve sample content and ordering:
         # the flat array is [L0, R0, L1, R1, ...].
         expected = np.arange(44100 * 4, dtype=np.int16).reshape((-1, 2))
@@ -154,10 +152,10 @@ class TestFeed(unittest.TestCase):
                 float(np.corrcoef(written[:, 0], data[:, 1])[0, 1]), 0.5)
 
             # ...and feed's own reader must agree with soundfile about it.
-            read_sr, read_samples, read_bitrate, read_audio_seg = read_audio(
+            read_sr, read_samples, read_bitrate = read_audio(
                 path, 'flac')
             self.assertEqual(read_sr, sample_rate)
-            self.assertEqual(read_audio_seg.channels, 2)
+            self.assertEqual(read_samples.ndim, 2)
             self.assertEqual(read_samples.shape, (frames, 2))
             self.assertGreater(read_bitrate, 0)
             self.assertAlmostEqual(read_samples.shape[0] / read_sr,
@@ -614,7 +612,7 @@ class TestFeed(unittest.TestCase):
         if not os.path.exists(_INPUT_TEST_MP3):
             self.skipTest("input_test.mp3 reference asset not present")
 
-        sample_rate, samples, bitrate, audio = read_audio(_INPUT_TEST_MP3,
+        sample_rate, samples, bitrate = read_audio(_INPUT_TEST_MP3,
                                                            format='mp3')
         channel = samples[:, 0].astype(np.float32)
         start = 7 * sample_rate
@@ -842,7 +840,7 @@ class TestFeed(unittest.TestCase):
         if not os.path.exists(_INPUT_TEST_MP3):
             self.skipTest("input_test.mp3 reference asset not present")
 
-        sample_rate, samples, bitrate, audio = read_audio(_INPUT_TEST_MP3,
+        sample_rate, samples, bitrate = read_audio(_INPUT_TEST_MP3,
                                                            format='mp3')
         channel = samples[:, 0].astype(np.float64)
         expanded = new_interpolation_algorithm(channel, upscale_factor=4)
@@ -1043,7 +1041,7 @@ class TestFeed(unittest.TestCase):
         if not os.path.exists(_INPUT_TEST_MP3):
             self.skipTest("input_test.mp3 reference asset not present")
 
-        sample_rate, samples, bitrate, audio = read_audio(_INPUT_TEST_MP3,
+        sample_rate, samples, bitrate = read_audio(_INPUT_TEST_MP3,
                                                            format='mp3')
         channel = samples[:, 0].astype(np.float64)
         expanded = new_interpolation_algorithm(channel, upscale_factor=7)
@@ -1244,10 +1242,11 @@ class TestFeed(unittest.TestCase):
         mock_audio = MagicMock()
         mock_audio.channels = 2
         rng = np.random.default_rng(7)
-        flat_samples = (rng.integers(-3000, 3000, size=n_frames * 2)
+        flat_samples = (rng.integers(-3000, 3000, size=(n_frames, 2))
                        .astype(np.int16))
+        print(flat_samples.ndim)
         mock_audio.get_array_of_samples.return_value = flat_samples
-        mock_read_audio.return_value = (sample_rate, None, None, mock_audio)
+        mock_read_audio.return_value = (sample_rate, flat_samples, None)
 
         original_nyquist = sample_rate / 2.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 pyfftw
-pydub
 soundfile
 mutagen
 scipy

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,11 @@ from setuptools import setup, find_packages
 
 setup(
     name='fat_llama_fftw',
-    version='1.4.1',
+    version='1.4.2',
     packages=find_packages(),
     install_requires=[
         'numpy',
         'pyfftw',
-        'pydub',
         'soundfile',
         'mutagen',
         'scipy',

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(
         'mutagen',
         'scipy',
     ],
+    extras_require={
+        'tests': 'pydub'
+    },
     package_data={
         'fat_llama_fftw': ['audio_fattener/*.py', 'tests/*.py'],
     },


### PR DESCRIPTION
Removes dependency pydub, because soundfile already provides needed functionality.
pydub still remains a dependency for unittests, though.